### PR TITLE
Logging commands without shortcut in output

### DIFF
--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -26,7 +26,9 @@ namespace ShowTheShortcut
             "Edit.GoToFindCombo",
             "Debug.LocationToolbar.ProcessCombo",
             "Debug.LocationToolbar.ThreadCombo",
-            "Debug.LocationToolbar.StackFrameCombo"
+            "Debug.LocationToolbar.StackFrameCombo",
+            "Build.SolutionPlatforms",
+            "Build.SolutionConfigurations"
         };
 
         private CommandHandler(DTE2 dte, Options options)
@@ -103,28 +105,33 @@ namespace ShowTheShortcut
 
                 string shortcut = GetShortcut(cmd);
 
-                if (!string.IsNullOrWhiteSpace(shortcut))
+                if (string.IsNullOrWhiteSpace(shortcut))
                 {
-                    if (_options.LogToStatusBar)
-                    {
-                        string prettyName = Prettify(cmd);
-                        string text = $"{prettyName} ({shortcut})";
+                    if (_options.LogCommandsWithoutShortcut)
+                        Logger.Log($"{cmd.Name} (no shortcut)");
 
-                        _control.SetVisibility(Visibility.Visible);
-                        _control.Text = text;
-                    }
+                    return;
+                }
 
-                    if (_options.ShowTooltip)
-                        _control.SetTooltip(cmd);
+                if (_options.LogToStatusBar)
+                {
+                    string prettyName = Prettify(cmd);
+                    string text = $"{prettyName} ({shortcut})";
 
-                    if (_options.LogToOutputWindow)
-                        Logger.Log($"{cmd.Name} ({shortcut})");
+                    _control.SetVisibility(Visibility.Visible);
+                    _control.Text = text;
+                }
 
-                    if (_options.Timeout > 0)
-                    {
-                        _timer.Stop();
-                        _timer.Start();
-                    }
+                if (_options.ShowTooltip)
+                    _control.SetTooltip(cmd);
+
+                if (_options.LogToOutputWindow)
+                    Logger.Log($"{cmd.Name} ({shortcut})");
+
+                if (_options.Timeout > 0)
+                {
+                    _timer.Stop();
+                    _timer.Start();
                 }
             }
             catch (Exception ex)

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -45,6 +45,12 @@ namespace ShowTheShortcut
         [DefaultValue(true)]
         public bool LogToOutputWindow { get; set; } = true;
 
+        [Category(OutputWindowCategory)]
+        [DisplayName("Log commands without shortcut")]
+        [Description("Log all commands captured to the Output Window.")]
+        [DefaultValue(true)]
+        public bool LogCommandsWithoutShortcut { get; set; } = true;
+
         public override void SaveSettingsToStorage()
         {
             base.SaveSettingsToStorage();


### PR DESCRIPTION
Description
-----
This PR adds functionality for easier finding of command names, when they don't have any shortcut assigned yet.

Fixes/Implements
-----
- Implements https://github.com/madskristensen/ShowTheShortcut/issues/6

Changes
-----
- Add new option for logging all commands into output
- Add new ignored commands (they were spamming output window every second)
- Add new logging of all commands, even those that have no shortcut