### PR TITLE
Show Guid and ID of any unknown commands

### DIFF
--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -98,7 +98,17 @@ namespace ShowTheShortcut
 
             try
             {
-                var cmd = _dte.Commands.Item(Guid, ID);
+                Command cmd = null;
+                try
+                {
+                    cmd = _dte.Commands.Item(Guid, ID);
+                }
+                catch (ArgumentException)
+                {
+                    if (_options.LogToOutputWindow)
+                        Logger.Log($"{Prettify(new Guid(Guid), ID)} (unknown command)");
+                    return;
+                }
 
                 if (string.IsNullOrWhiteSpace(cmd?.Name) || ShouldCommandBeIgnored(cmd))
                     return;
@@ -176,6 +186,11 @@ namespace ShowTheShortcut
 
             int index = cmd.LocalizedName.LastIndexOf('.') + 1;
             return cmd.LocalizedName.Substring(index);
+        }
+
+        private static string Prettify(Guid guid, int id)
+        {
+            return $"Guid={guid:B}, ID=0x{2343:x4}";
         }
 
         private static bool IsShortcutInteresting(string shortcut)


### PR DESCRIPTION
Previously an `System.ArgumentException` was being thrown. This PR changes it to show something like this on the Output window:

```
Guid={2005db2a-ba93-4b22-bf4a-2bb76c41ad8f}, ID=0x0927 (unknown command)
```

Fixes #11