### PR TITLE
**Updated:** VSIX Manifest to also allow different Versions of Visual Studio in addition to Pro. (Community/Premium/Ultimate)

### DIFF
--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -12,7 +12,10 @@
         <Tags>keyboard, shortcut, commands</Tags>
     </Metadata>
     <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)" />
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="[15.0, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="[15.0, 17.0)" />
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
I'v had a look into this one and I think this should now allow these Versions of Visual Studio to be compatible now. (Community/Premium/Ultimate)

Where currently Pro looks to be the only compatible Visual Studio version at present with this extension.

[Issue# 18 - Only compatible with Professional Edition](https://github.com/madskristensen/ShowTheShortcut/issues/18)

Hope this helps!