### PR TITLE
Fix Console window is overflooded #14

### DIFF
--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -105,7 +105,7 @@ namespace ShowTheShortcut
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			if (!_showShortcut)
+			if (!_showShortcut || !(CustomIn is null) || !(CustomOut is null))
 			{
 				return;
 			}


### PR DESCRIPTION
Fix Console window is overflooded #14

Change the CommandHandler.AfterExecute method to return immedately if
the or CustomIn or CustomOut parameter is not null.

If either of these parameters is not null, it is unlikely that the
command was invoked by a shortcut or via the UI. In the case of
an editable combobox in a toolbar, its command handler will return
the values of the combobox items in the CustomOut parameter. Therefore
when CustomOut is not null, the command handler is not actually
executing the command.